### PR TITLE
Improve `<title>` update

### DIFF
--- a/src/js/burokku.js
+++ b/src/js/burokku.js
@@ -12,14 +12,13 @@ const installBtnVisible = 'app-install--visible'
 class Burokku {
   constructor() {
     this.doc = document.documentElement
-    this.title = document.head.querySelector('title')
 
     this.init()
   }
 
   updateTitle() {
     if (this.wallet.money) {
-      this.title.innerHTML = `x ${this.wallet.money} • ${this.blocks.active.btn.dataset.game}`
+      document.title = `x ${this.wallet.money} • ${this.blocks.active.btn.dataset.game}`
     }
   }
 


### PR DESCRIPTION
It turns out [`document.title` is a getter/setter property for `<title>` `innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Document/title).