### PR TITLE
Use `textContent` instead of `innerHTML`

### DIFF
--- a/src/js/modules/Settings/index.js
+++ b/src/js/modules/Settings/index.js
@@ -36,7 +36,7 @@ export default class Setting {
     // Update UI
     this.btn.classList.toggle('setting--on', state)
     this.btn.setAttribute('title', this.labels[this.#enabled])
-    this.labelEl.innerHTML = this.labels[this.#enabled]
+    this.labelEl.textContent = this.labels[this.#enabled]
   }
 
   detectSupport(supported = true) {

--- a/src/js/modules/Wallet.js
+++ b/src/js/modules/Wallet.js
@@ -74,7 +74,7 @@ class Wallet {
    * Show coins amount
    */
   display() {
-    this.output.innerHTML = this.coins
+    this.output.textContent = this.coins
   }
 
   /**


### PR DESCRIPTION
It has better performances for text-only nodes as it [doesn’t need to be parsed as HTML](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innerhtml).