### PR TITLE
Remove unneeded `noopener` attribute on links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -148,7 +148,7 @@
                 <aside>
                     <ul class="menu__links">
                         <li class="menu__linksItem">
-                            <a class="menu__link | flex-center" href="https://m.nintendojo.fr/@sunappu" target="_blank" rel="noopener" title="Follow Sunappu on Mastodon">
+                            <a class="menu__link | flex-center" href="https://m.nintendojo.fr/@sunappu" target="_blank" title="Follow Sunappu on Mastodon">
                                 <svg class="menu__svg menu__svg--mastodon" width="13" height="14">
                                     <use xlink:href="#mastodon-path"/>
                                 </svg>
@@ -156,7 +156,7 @@
                             </a>
                         </li>
                         <li class="menu__linksItem">
-                            <a class="menu__link | flex-center" href="https://github.com/sunappu-dojo/burokku" target="_blank" rel="noopener" title="Source code">
+                            <a class="menu__link | flex-center" href="https://github.com/sunappu-dojo/burokku" target="_blank" title="Source code">
                                 <svg class="menu__svg menu__svg--code" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
                                     <path d="M8.3 6.3L2.6 12l5.7 5.7 1.4-1.4L5.4 12l4.3-4.3zm7.4 11.4l5.7-5.7-5.7-5.7-1.4 1.4 4.3 4.3-4.3 4.3z"/>
                                 </svg>


### PR DESCRIPTION
Not needed anymore on supported browsers.

https://caniuse.com/mdn-html_elements_a_implicit_noopener