### PR TITLE
Fix ESLint autosave and enable ESLint cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@babel/plugin-proposal-private-methods": "^7.14.5",
                 "@babel/preset-env": "^7.23",
                 "@fullhuman/postcss-purgecss": "^5",
+                "@rollup/plugin-eslint": "^9.0.5",
                 "@size-limit/preset-app": "^11",
                 "browserslist": "^4.22.3",
                 "browserslist-to-esbuild": "^2.0.0",
@@ -31,7 +32,6 @@
                 "size-limit": "^11",
                 "v.scss": "^1.2.1",
                 "vite": "^5",
-                "vite-plugin-eslint": "^1.8",
                 "vite-plugin-html": "^3.2.1",
                 "vite-plugin-singlefile": "^1.0"
             },
@@ -116,9 +116,9 @@
             }
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.23.9",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.9.tgz",
-            "integrity": "sha512-xPndlO7qxiJbn0ATvfXQBjCS7qApc9xmKHArgI/FTEFxXas5dnjC/VqM37lfZun9dclRYcn+YQAr6uDFy0bB2g==",
+            "version": "7.23.10",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz",
+            "integrity": "sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==",
             "dev": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -3254,6 +3254,49 @@
                 "node": ">=16.3.0"
             }
         },
+        "node_modules/@rollup/plugin-eslint": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-eslint/-/plugin-eslint-9.0.5.tgz",
+            "integrity": "sha512-C4nh0sSeJuxVW5u5tDX+dCMjKcNfHm4hS+zeUVh1si7gttnhgGbrmPkUxIX7iZgYABwdEh/ewyMbZB+WXjSJdA==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "eslint": "^8.24.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-eslint/node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rollup/pluginutils": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -3516,26 +3559,10 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/@types/eslint": {
-            "version": "8.4.6",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
-            }
-        },
         "node_modules/@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
             "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-            "dev": true
-        },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -6461,9 +6488,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.33",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-            "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+            "version": "8.4.35",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+            "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8553,13 +8580,13 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "5.0.12",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
-            "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.1.tgz",
+            "integrity": "sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.19.3",
-                "postcss": "^8.4.32",
+                "postcss": "^8.4.35",
                 "rollup": "^4.2.0"
             },
             "bin": {
@@ -8605,36 +8632,6 @@
                 "terser": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vite-plugin-eslint": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
-            "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/pluginutils": "^4.2.1",
-                "@types/eslint": "^8.4.5",
-                "rollup": "^2.77.2"
-            },
-            "peerDependencies": {
-                "eslint": ">=7",
-                "vite": ">=2"
-            }
-        },
-        "node_modules/vite-plugin-eslint/node_modules/rollup": {
-            "version": "2.79.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-            "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-            "dev": true,
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/vite-plugin-html": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@babel/plugin-proposal-private-methods": "^7.14.5",
         "@babel/preset-env": "^7.23",
         "@fullhuman/postcss-purgecss": "^5",
+        "@rollup/plugin-eslint": "^9.0.5",
         "@size-limit/preset-app": "^11",
         "browserslist": "^4.22.3",
         "browserslist-to-esbuild": "^2.0.0",
@@ -40,8 +41,11 @@
         "size-limit": "^11",
         "v.scss": "^1.2.1",
         "vite": "^5",
-        "vite-plugin-eslint": "^1.8",
         "vite-plugin-html": "^3.2.1",
         "vite-plugin-singlefile": "^1.0"
+    },
+    "overrides": {
+        "has": "npm:@nolyfill/has@latest",
+        "hasown": "npm:@nolyfill/hasown@latest"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 import { createHtmlPlugin } from 'vite-plugin-html'
 import { viteSingleFile } from 'vite-plugin-singlefile'
 import browserslistToEsbuild from 'browserslist-to-esbuild'
-import eslintPlugin from 'vite-plugin-eslint'
+import eslintPlugin from '@rollup/plugin-eslint'
 
 const isProd = env?.NODE_ENV === 'production'
 
@@ -17,10 +17,11 @@ if (outDir.includes('../')) {
 
 // ESLint Options
 const esLintOptions = {
-  cache: false, // cache is cleaned on `npm install`
+  cache: true, // cache is cleaned on `npm install`
   cacheStrategy: 'content',
   fix: env?.ES_LINT_AUTOFIX == 'true',
   formatter: env?.ES_LINT_FORMATTER ?? 'stylish',
+  include: '**/*.+(js|ts)',
 }
 
 // HTML plugin option (https://github.com/vbenjs/vite-plugin-html#parameter-description)
@@ -42,6 +43,10 @@ const singleFileOptions = {
 
 export default defineConfig({
   root: 'src',
+
+  css: {
+    devSourcemap: true,
+  },
 
   build: {
     envDir: './',
@@ -88,10 +93,14 @@ export default defineConfig({
   },
 
   plugins: isProd ? [
-    eslintPlugin(esLintOptions),
     createHtmlPlugin(htmlOptions),
     viteSingleFile(singleFileOptions),
-  ] : [],
+  ] : [
+    {
+      ...eslintPlugin(esLintOptions),
+      enforce: 'pre',
+    },
+  ],
 
   server: {
     open: env?.BROWSER_OPEN == 'true',


### PR DESCRIPTION
Replace [`vite-eslint-plugin`](https://www.npmjs.com/package/vite-plugin-eslint) by [`@rollup/plugin-eslint`](https://www.npmjs.com/package/@rollup/plugin-eslint), thou the Vite config fix also works with both packages.

Also enables CSS sourcemaps during development.