### PR TITLE
Prevent the bold font to be loaded too soon

### DIFF
--- a/src/css/components/menu/index.css
+++ b/src/css/components/menu/index.css
@@ -8,6 +8,7 @@
 
 @import url(./separator.css);
 @import url(./links.css);
+@import url(./quirks.css);
 
 .menu-visible {
   --menu-visible: 1;

--- a/src/css/components/menu/quirks.css
+++ b/src/css/components/menu/quirks.css
@@ -1,7 +1,7 @@
 /**
  * This rule prevents the bold font to be loaded until the menu is ready,
  * since the menu is the only place needing this `font-weight` when it
- * displays “Auto” (in bold) when the system color scheme is chosen.
+ * displays “Auto” (in bold) when a system color scheme is prefered.
  */
 .menu__bold {
   font-weight: calc(400 + 300 * var(--menu-ready));

--- a/src/css/components/menu/quirks.css
+++ b/src/css/components/menu/quirks.css
@@ -1,0 +1,9 @@
+/**
+ * This rule prevents the bold font to be loaded until the menu is ready,
+ * since the menu is the only place need ing this `font-weight`. It is
+ * used for the color scheme when “Auto” (shown in bold) is chosen.
+ */
+
+.menu__bold {
+  font-weight: calc(400 + 300 * var(--menu-ready));
+}

--- a/src/css/components/menu/quirks.css
+++ b/src/css/components/menu/quirks.css
@@ -1,9 +1,8 @@
 /**
  * This rule prevents the bold font to be loaded until the menu is ready,
- * since the menu is the only place need ing this `font-weight`. It is
- * used for the color scheme when “Auto” (shown in bold) is chosen.
+ * since the menu is the only place needing this `font-weight` when it
+ * displays “Auto” (in bold) when the system color scheme is chosen.
  */
-
 .menu__bold {
   font-weight: calc(400 + 300 * var(--menu-ready));
 }

--- a/src/css/components/menu/toggle-btn.css
+++ b/src/css/components/menu/toggle-btn.css
@@ -10,6 +10,7 @@
 }
 
 .menu-toggle-visible {
+  --menu-ready: 1;
   --menu-toggle-opacity: .6; // same value as settings button (e.g. sound)
   --app-install-x: 0;
 }

--- a/src/css/utils/headlines.css
+++ b/src/css/utils/headlines.css
@@ -7,3 +7,8 @@
     font-size: 4rem;
   }
 }
+
+// Prevent `font-weight: bold` to be set on `h{n}.visually-hidden`.
+:where(h1, h2, h3, h4, h5, h6) {
+  font-weight: inherit;
+}

--- a/src/js/modules/ColorSchemes/index.js
+++ b/src/js/modules/ColorSchemes/index.js
@@ -19,7 +19,9 @@ const colorSchemeNames = {
   light: 'Basic White',
 }
 
-const getColorSchemeName = (scheme, applied) => colorSchemeNames[scheme] ?? `<strong>Auto</strong> (${colorSchemeNames[applied]})`
+const getColorSchemeName = (scheme, applied) =>
+  colorSchemeNames[scheme]
+  ?? `<strong class="menu__bold">Auto</strong> (${colorSchemeNames[applied]})`
 
 class ColorSchemes {
 


### PR DESCRIPTION
This saves one `.woff2` request on first load.