### PR TITLE
Clean legacy CSS font stack

### DIFF
--- a/src/css/base/html-and-body.css
+++ b/src/css/base/html-and-body.css
@@ -3,7 +3,7 @@
 :where(:root) {
   size: 100% 100%;
 
-  font: 50% / 1.4 'Oxygen', system-ui, sans-serif;;
+  font: 50% / 1.4 'Oxygen', system-ui, sans-serif;
   text-size-adjust: 100%; // Prevent adjustments of font size after orientation changes in iOS.
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;

--- a/src/css/base/html-and-body.css
+++ b/src/css/base/html-and-body.css
@@ -3,7 +3,7 @@
 :where(:root) {
   size: 100% 100%;
 
-  font: 50% / 1.4 'Oxygen', system-ui, -apple-system, sans-serif;;
+  font: 50% / 1.4 'Oxygen', system-ui, sans-serif;;
   text-size-adjust: 100%; // Prevent adjustments of font size after orientation changes in iOS.
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
`-apple-system` is not needed anymore since there’s now 100% support for [`system-ui`](https://caniuse.com/font-family-system-ui) among the project supported browsers.