### PR TITLE
Fix outline visible inside the `on-hover` button

### DIFF
--- a/src/css/components/btn/on-hover.css
+++ b/src/css/components/btn/on-hover.css
@@ -3,8 +3,7 @@
 .cta--on-hover {
   background: none;
   border-color: transparent;
-  outline: .1rem solid var(--bg);
-  outline-offset: -.5rem;
+  outline: none;
 
   animation: none;
 


### PR DESCRIPTION
Remove the light grey rectangle inside the button when hover or focused:

hover or focus:

<img width="313" alt="a nice button with a delightful sun icon and a crappy grey rectangle inside its awesome focus ring" src="https://github.com/user-attachments/assets/ce3f1b6e-57bd-41a8-b5e7-02baf2e4a26a" />

no hover nor focus:

<img width="359" alt="a button with a sun icon" src="https://github.com/user-attachments/assets/47f08340-13a9-4025-a4d7-1ece3e6b2cd3" />
